### PR TITLE
Add GetFoulData endpoint

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,10 +1,22 @@
 from ninja import Router
 from ninja.errors import HttpError
-from requests import request as HTTPRequest
 
 from api.views import *
 
 router = Router()
+
+
+@router.get("/helloworld")
+def helloworld(request):
+    return {"msg": 'Hello world'}
+
+
+@router.get('/getFoulData')
+def test_pasi(request, foul_number: int = 113148427, register_number: str = "HKR-999"):
+    req = PASIHandler.getFoulData(request, foul_number, register_number)
+    if req.status_code != 200:
+        raise HttpError(req.status_code, req.json())
+    return req.json()
 
 
 @router.get('/getDocuments')
@@ -12,12 +24,6 @@ def test_data(request):
     req = ATVHandler.get_documents(request)
     if req.status_code != 200:
         raise HttpError(req.status_code, req.json())
-    return req.json()
-
-
-@router.get('/testPasi')
-def test_pasi(request):
-    req = HTTPRequest("POST", url="http://10.182.254.208:8443/api/fouls/GetFoulData")
     return req.json()
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -32,3 +32,29 @@ class ATVHandler:
             return req
         except Exception as error:
             return str(error)
+
+
+class PASIHandler:
+
+    def getFoulData(self, foul_number, register_number):
+        print(foul_number, register_number)
+        try:
+            req = request("POST", url=f"{env('PASI_ENDPOINT')}/api/v1/fouls/GetFoulData",
+                          verify=False,
+                          headers={'content-type': 'application/json', 'x-api-version': '1.0'},
+                          json={
+
+                              "username": "string",
+                              "password": "string",
+                              "customerID": {
+                                  "id": "string",
+                                  "type": 0
+                              },
+                              "customerLanguage": 0,
+                              "customerIPAddress": "string",
+                              "foulNumber": foul_number,
+                              "registerNumber": f"{register_number}"
+                          })
+            return req
+        except Exception as error:
+            return str(error)

--- a/pysakoinnin_sahk_asiointi/urls.py
+++ b/pysakoinnin_sahk_asiointi/urls.py
@@ -8,15 +8,9 @@ from api.api import router as api_router
 
 api = NinjaAPI()
 
-api.add_router('/api/v1', api_router)
-
-
-@api.get("/helloworld")
-def helloworld(request):
-    return {"msg": 'Hello world'}
-
+api.add_router('/v1/', api_router)
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-    path("api/v1/", api.urls)
+    path("api/", api.urls)
 ]


### PR DESCRIPTION
This PR:
- Adds `/getFoulData` endpoint that fetches foul data from PASI test server
  - Uses GET query params