### PR TITLE
Add status endpoint operations

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -51,7 +51,7 @@ class ATVHandler:
             req = request('POST', f"{env('ATV_ENDPOINT')}",
                           headers={"x-api-key": env('ATV_API_KEY')}, data={
                     "user_id": user_id,
-                    "draft": True,
+                    "draft": False,
                     "transaction_id": f"{foul_id}",
                     "tos_record_id": 12345,
                     "tos_function_id": 12345,

--- a/api/views.py
+++ b/api/views.py
@@ -51,10 +51,11 @@ class ATVHandler:
             req = request('POST', f"{env('ATV_ENDPOINT')}",
                           headers={"x-api-key": env('ATV_API_KEY')}, data={
                     "user_id": user_id,
-                    "draft": False,
+                    "draft": True,
                     "transaction_id": f"{foul_id}",
                     "tos_record_id": 12345,
                     "tos_function_id": 12345,
+                    "status": "sent",
                     "content": json.dumps({**Objection.dict(objection)})},
                           files={'attachments': None})
             return req.json()
@@ -138,4 +139,19 @@ class DocumentHandler:
 
     @staticmethod
     def set_document_status(status_request: DocumentStatusRequest):
-        print(status_request)
+        find_document_by_id = ATVHandler.get_document_by_transaction_id(status_request.id)
+        document_id = find_document_by_id["results"][0]['id']
+
+        try:
+            req = request('PATCH', f"{env('ATV_ENDPOINT')}{document_id}/",
+                          headers={"x-api-key": env('ATV_API_KEY'),
+                                   "accept": "application/json"},
+                          data={"status": status_request.status.value},
+                          files={"attachments": None})
+
+            response_json = req.json()
+            if hasattr(response_json, "id") is None:
+                raise HttpError(404, message="Resource not found")
+            return {200, "OK"}
+        except HttpError as error:
+            return error


### PR DESCRIPTION
This PR:
- Adds ATV operations to `setDocumentStatus` endpoint
- Adds default "sent" value when creating new document