### PR TITLE
Add ATV operation to save objection endpoint

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -58,7 +58,7 @@ def save_objection(request, objection: Objection):
     """
     Send a new objection to PASI
     """
-    req = PASIHandler.save_objection(objection)
+    req = PASIHandler.save_objection(objection, user_id=request.user.uuid)
     return req.json()
 
 
@@ -78,17 +78,6 @@ def get_document_by_transaction_id(request, id):
     Get document from ATV by foul ID
     """
     req = ATVHandler.get_document_by_transaction_id(id)
-    return req
-
-
-@router.post('/sendObjection/{foul_id}',
-             response={200: None, 201: ATVDocumentResponse, 400: None, 401: None},
-             tags=['ATV'])
-def send_objection_to_atv(request, objection: Objection, foul_id: str):
-    """
-    Upload new user document to ATV
-    """
-    req = ATVHandler.add_document(objection, foul_id, user_id=request.user.uuid)
     return req
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -128,7 +128,7 @@ class PASIHandler:
             raise HttpError(500, message=str(error))
 
     @staticmethod
-    def save_objection(objection: Objection):
+    def save_objection(objection: Objection, user_id):
         try:
             req = request("POST", url=f"{env('PASI_ENDPOINT')}/api/v1/Objections/SaveObjection",
                           verify=False,
@@ -139,6 +139,8 @@ class PASIHandler:
                           )
             if req.status_code == 422:
                 raise HttpError(422, message=req.json())
+            if hasattr(req, "json"):
+                ATVHandler.add_document(objection, str(objection.foulNumber), user_id)
             return req
         except HttpError as error:
             raise error


### PR DESCRIPTION
This PR:
- Adds objection to ATV on successful save_objection PASI request
- Removes separate `sendObjection` ATV endpoint