### PR TITLE
Add either foul or transfer number to saved objection in ATV

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,3 +1,4 @@
+import ninja.errors
 from django.http import HttpRequest
 from environ import Env
 from ninja import Router, Schema
@@ -55,10 +56,16 @@ def extend_due_date(request, foul_data: FoulRequest):
 
 @router.post('/saveObjection', response={200: None, 204: None, 422: None}, tags=['PASI'])
 def save_objection(request, objection: Objection):
+    if hasattr(objection, "foulNumber") and objection.foulNumber is not None:
+        objection_id = objection.foulNumber
+    elif hasattr(objection, "transferNumber") and objection.transferNumber is not None:
+        objection_id = objection.transferNumber
+    else:
+        raise ninja.errors.HttpError(422, message="Foul number or transfer number missing")
     """
     Send a new objection to PASI
     """
-    req = PASIHandler.save_objection(objection, user_id=request.user.uuid)
+    req = PASIHandler.save_objection(objection, objection_id, user_id=request.user.uuid)
     return req.json()
 
 

--- a/api/views.py
+++ b/api/views.py
@@ -47,7 +47,6 @@ class ATVHandler:
 
     @staticmethod
     def add_document(content, document_id, user_id: str):
-        print("Value in ATV handler", document_id)
         try:
             req = request('POST', f"{env('ATV_ENDPOINT')}",
                           headers={"x-api-key": env('ATV_API_KEY')}, data={
@@ -130,7 +129,6 @@ class PASIHandler:
 
     @staticmethod
     def save_objection(objection: Objection, objection_id, user_id):
-        print("Value in Pasi handler", objection_id)
         try:
             req = request("POST", url=f"{env('PASI_ENDPOINT')}/api/v1/Objections/SaveObjection",
                           verify=False,

--- a/api/views.py
+++ b/api/views.py
@@ -46,14 +46,15 @@ class ATVHandler:
             raise error
 
     @staticmethod
-    def add_document(content, foul_id: str, user_id: str):
+    def add_document(content, document_id, user_id: str):
+        print("Value in ATV handler", document_id)
         try:
             req = request('POST', f"{env('ATV_ENDPOINT')}",
                           headers={"x-api-key": env('ATV_API_KEY')}, data={
                     "user_id": user_id,
                     "draft": False,
                     "deletable": False,
-                    "transaction_id": f"{foul_id}",
+                    "transaction_id": f"{str(document_id)}",
                     "tos_record_id": 12345,
                     "tos_function_id": 12345,
                     "status": "sent",
@@ -128,7 +129,8 @@ class PASIHandler:
             raise HttpError(500, message=str(error))
 
     @staticmethod
-    def save_objection(objection: Objection, user_id):
+    def save_objection(objection: Objection, objection_id, user_id):
+        print("Value in Pasi handler", objection_id)
         try:
             req = request("POST", url=f"{env('PASI_ENDPOINT')}/api/v1/Objections/SaveObjection",
                           verify=False,
@@ -140,7 +142,7 @@ class PASIHandler:
             if req.status_code == 422:
                 raise HttpError(422, message=req.json())
             if hasattr(req, "json"):
-                ATVHandler.add_document(**Objection.dict(objection), foul_id=str(objection.foulNumber), user_id=user_id)
+                ATVHandler.add_document(**Objection.dict(objection), document_id=objection_id, user_id=user_id)
             return req
         except HttpError as error:
             raise error


### PR DESCRIPTION
This PR:
- Checks if either transfer number or foul number exists and is a non-zero value and uses it to identify document in ATV