### PR TITLE
Django mailer

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -12,6 +12,8 @@ from api.utils import virus_scan_attachment_file
 from api.views import PASIHandler, ATVHandler, DocumentHandler
 from mail_service.audit_log import _commit_to_audit_log
 from mail_service.utils import mail_constructor, extend_due_date_mail_constructor
+from django.core.management import call_command
+
 
 router = Router()
 env = Env()
@@ -25,6 +27,13 @@ class ApiKeyAuth(HttpBearer):
 
 class NotFoundError(Schema):
     detail: str = "Resource not found"
+
+# Can be used to test sending emails from api/v1 docs, delete after testing is done.
+@router.get('/testSendQue', response={200: None, 500: None}, tags=['email'])
+def test_send_que(request, recipent: str = "email@email.com"):
+    # triggers: python manage.py send_mail
+    call_command('send_mail')
+    return 200
 
 # Can be used to test sending emails from api/v1 docs, delete after testing is done.
 @router.get('/testEmailSending', response={200: None, 500: None}, tags=['email'])

--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -68,6 +68,7 @@ INSTALLED_APPS = [
     "ninja",
     "corsheaders",
     "anymail",
+    "mailer"
 ]
 
 MIDDLEWARE = [
@@ -165,7 +166,11 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+
+EMAIL_BACKEND = "mailer.backend.DbBackend"
+# From mailer docs
+# If you were previously using a non-default EMAIL_BACKEND, you need to configure the MAILER_EMAIL_BACKEND setting, so that django-mailer knows how to actually send the mail:
+MAILER_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
 EMAIL_HOST = "relay.hel.fi"
 EMAIL_PORT = 25

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ sentry-sdk
 gunicorn
 django-anymail
 cryptography
+django-mailer

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,6 +30,7 @@ django==3.2.21
     #   django-anymail
     #   django-cors-headers
     #   django-helusers
+    #   django-mailer
     #   django-ninja
 django-anymail==10.0
     # via -r requirements.in
@@ -38,6 +39,8 @@ django-cors-headers==3.13.0
 django-environ==0.9.0
     # via -r requirements.in
 django-helusers==0.8.1
+    # via -r requirements.in
+django-mailer==2.2.1
     # via -r requirements.in
 django-ninja==0.19.1
     # via -r requirements.in
@@ -51,6 +54,8 @@ idna==3.4
     # via requests
 iniconfig==2.0.0
     # via pytest
+lockfile==0.12.2
+    # via django-mailer
 packaging==21.3
     # via
     #   deprecation


### PR DESCRIPTION
Add mails to queue to provide possibility to handle sending with cronjobs. 

Note that no mail is being sent unless cronjob has been executed.