### PR TITLE
Merge dev into main

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -12,12 +12,9 @@ from api.utils import virus_scan_attachment_file
 from api.views import PASIHandler, ATVHandler, DocumentHandler
 from mail_service.audit_log import _commit_to_audit_log
 from mail_service.utils import mail_constructor, extend_due_date_mail_constructor
-from django.core.management import call_command
-
 
 router = Router()
 env = Env()
-
 
 class ApiKeyAuth(HttpBearer):
     def authenticate(self, request: HttpRequest, token: str):

--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -173,6 +173,11 @@ EMAIL_BACKEND = "mailer.backend.DbBackend"
 # Sometimes this is referred in code directly to skip queue
 MAILER_EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 
+MAILER_ERROR_HANDLER = "mail_service.utils.custom_mailer_error_handler"
+
+# After how many failed attempts email is not being put back to queue with retry_deferred command
+MAILER_EMAIL_MAX_RETRIES = 5
+
 EMAIL_HOST = "relay.hel.fi"
 EMAIL_PORT = 25
 EMAIL_USE_TLS = True


### PR DESCRIPTION
Auditlogging is for errors while django-mailer gets send_mail command. No additional logging for successful event is being created. 

Successful logs are defaulted to DB.

