### PR TITLE
chore: add data scrubbing for sentry events

### DIFF
--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -6,6 +6,9 @@ import sentry_sdk
 from corsheaders.defaults import default_headers
 from environ import Env
 from sentry_sdk.integrations.django import DjangoIntegration
+from sentry_sdk.scrubber import EventScrubber, DEFAULT_DENYLIST
+
+from pysakoinnin_sahk_asiointi.utils import sentry_scrubber
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -45,11 +48,22 @@ if DEBUG and not SECRET_KEY:
     SECRET_KEY = 'XXX'
 
 # Sentry config
+sentry_deny_list = DEFAULT_DENYLIST + [
+    "ssn",
+    "address",
+    "firstName",
+    "lastName",
+    "mobilePhone",
+    "email",
+    "registerNumber"
+]
+
 sentry_sdk.init(
     dsn=env('SENTRY_DSN'),
     integrations=[DjangoIntegration()],
-
+    event_scrubber=EventScrubber(denylist=sentry_deny_list),
     traces_sample_rate=env('SENTRY_TRACE_SAMPLE_RATE'),
+    before_send=sentry_scrubber
 )
 
 # Application definition

--- a/pysakoinnin_sahk_asiointi/utils.py
+++ b/pysakoinnin_sahk_asiointi/utils.py
@@ -1,6 +1,32 @@
+import logging
+
+
 def stringToBool(strBool: str, default: bool):
     if strBool.lower() == "true":
         return True
     if strBool.lower() == "false":
         return False
     return default
+
+
+def sentry_scrubber(*args, **kwargs):
+    event = args[0]
+
+    if not event:
+        return
+
+    # Objection are stored in stacktrace and might contain sensitive data, and we want it to be scrubbed.
+    lookup_objects = ["objection", "sanitised_objection", "objection_without_attachment_data"]
+    try:
+        for value in event.get("exception", {}).get("values", []):
+            for frame in value.get("stacktrace", {}).get("frames", []):
+                for var in (frame_vars := frame.get("vars", [])):
+                    if var in lookup_objects:
+                        frame_vars[var] = "Scrubbed"
+                    for val in (values := frame_vars.get("values", [])):
+                        if val in lookup_objects:
+                            values[val] = "Scrubbed"
+    except: # noqa
+        logging.error("Failed to scrub objection data")
+
+    return event


### PR DESCRIPTION
Some events contained too much information so this adds a custom sentry data scrubber which wipes somes data from sentry events.

Refs RATY-103