### PR TITLE
Fix objection saving

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,7 @@
 Django~=4.2
 django-cors-headers
 django-environ
-django-ninja
+django-ninja<1
 django-helusers
 pytest-django
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -87,7 +87,7 @@ python-dateutil==2.9.0.post0
     # via -r requirements.in
 python-jose==3.3.0
     # via django-helusers
-requests==2.32.0
+requests==2.32.3
     # via
     #   django-anymail
     #   django-helusers

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@
 #
 #    pip-compile
 #
-annotated-types==0.6.0
-    # via pydantic
 asgiref==3.8.1
     # via
     #   django
@@ -44,7 +42,7 @@ django-helusers==0.11.0
     # via -r requirements.in
 django-mailer==2.3.1
     # via -r requirements.in
-django-ninja==1.1.0
+django-ninja==0.22.2
     # via -r requirements.in
 ecdsa==0.19.0
     # via python-jose
@@ -75,10 +73,8 @@ pyclamd==0.4.0
     # via -r requirements.in
 pycparser==2.22
     # via cffi
-pydantic==2.7.1
+pydantic==1.10.16
     # via django-ninja
-pydantic-core==2.18.2
-    # via pydantic
 pytest==8.2.1
     # via
     #   pytest-cov
@@ -113,7 +109,6 @@ typing-extensions==4.11.0
     # via
     #   asgiref
     #   pydantic
-    #   pydantic-core
 urllib3==2.2.1
     # via
     #   django-anymail


### PR DESCRIPTION
Upgrading django-ninja to v1.x broke objection saving functionality at least of [the current UI](https://github.com/City-of-Helsinki/pysakoinnin-sahk-asiointi-ui/releases/tag/pysakoinnin-sahk-asiointi-ui-v0.10.0), so it was downgraded back to v0.x.

This PR also includes requests bump to v2.32.3, because the previously used version v2.32.0 [was yanked](https://pypi.org/project/requests/2.32.0/).