### PR TITLE
Dependabot improvements

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "deps"
+    # Disable version updates and only allow security updates
+    open-pull-requests-limit: 0


### PR DESCRIPTION
By default, Dependabot creates commits with type "chore". Changed the type to "deps" which is the correct type for dependencies in our projects. "chore" was particularly problematic because it doesn't cause release-please to create a new release.

Refs [RAT-201](https://helsinkisolutionoffice.atlassian.net/browse/RAT-201)