### PR TITLE
fix: sentry scrub recursively and deny "request" and "body"

### DIFF
--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -65,12 +65,14 @@ sentry_deny_list = DEFAULT_DENYLIST + [
     "email",
     "registerNumber",
     "register_number",
+    "request",  # WSGIRequest.__str__ may contain query params
+    "body",  # request body encoded in JSON in urllib3
 ]
 
 sentry_sdk.init(
     dsn=env("SENTRY_DSN"),
     integrations=[DjangoIntegration()],
-    event_scrubber=EventScrubber(denylist=sentry_deny_list),
+    event_scrubber=EventScrubber(denylist=sentry_deny_list, recursive=True),
     traces_sample_rate=env("SENTRY_TRACE_SAMPLE_RATE"),
     before_send=sentry_scrubber,
 )


### PR DESCRIPTION
Recursive scrubber applies the denylist recursively on dicts which works pretty well for most cases. In addition, urllib3's exception frame contained the PASI request payload as binary and some other frame contained string representation of WSGIRequest with sensitive data visible.

This does not fix query params having sensitive information - that would require migrating from using GET requests to POST requests.

Refs: [PSA-17](https://helsinkisolutionoffice.atlassian.net/browse/PSA-17)