### PR TITLE
fix!: remove getDocumentByTransactionId endpoint

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -150,20 +150,6 @@ def get_atv_documents(request):
     return response
 
 
-@router.get(
-    "/getDocumentByTransactionId/{id}",
-    response={200: ATVDocumentResponse, 404: NotFoundError, 500: None},
-    tags=["ATV"],
-)
-def get_document_by_transaction_id(request, id):
-    """
-    Get document from ATV by foul ID
-    """
-    response = ATVHandler.get_document_by_transaction_id(id)
-
-    return response
-
-
 @router.patch(
     "/setDocumentStatus",
     response={200: None, 401: None, 404: NotFoundError, 422: None},

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -101,17 +101,6 @@ class TestApiFunctions(TestCase):
 
         assert result.json() == MOCK_ATV_DOCUMENT_RESPONSE
 
-    @patch("api.views.ATVHandler.get_document_by_transaction_id")
-    def test_get_document_by_transaction_id(self, get_document_by_transaction_id_mock):
-        get_document_by_transaction_id_mock.return_value = MockResponse(
-            200, MOCK_ATV_DOCUMENT_RESPONSE
-        )
-
-        random_id = 12345
-        result = api.get_document_by_transaction_id(request=None, id=random_id)
-
-        assert result.json() == MOCK_ATV_DOCUMENT_RESPONSE
-
     @patch("api.views.ATVHandler.add_document")
     @patch("api.views.PASIHandler.save_objection")
     def test_save_objection(self, save_objection_mock, add_document_mock):

--- a/api/tests/test_endpoints.py
+++ b/api/tests/test_endpoints.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from api.tests.mocks import (
-    MOCK_ATV_DOCUMENT_RESPONSE,
     MOCK_FOUL,
     MOCK_TRANSFER,
     MockResponse,
@@ -28,17 +27,5 @@ class TestEndpoints(TestCase):
         get_transfer_data_mock.return_value = MockResponse(200, MOCK_TRANSFER)
 
         response = self.client.get(f"{API_ROOT}/getTransferData")
-
-        assert response.status_code == 401
-
-    @patch("api.views.ATVHandler.get_document_by_transaction_id")
-    def test_get_document_by_transaction_id_unauth(
-        self, get_document_by_transaction_id_mock
-    ):
-        get_document_by_transaction_id_mock.return_value = MockResponse(
-            200, MOCK_ATV_DOCUMENT_RESPONSE
-        )
-
-        response = self.client.get(f"{API_ROOT}/getDocumentByTransactionId/12345")
 
         assert response.status_code == 401

--- a/api/views.py
+++ b/api/views.py
@@ -39,6 +39,9 @@ class ATVHandler:
 
     @staticmethod
     def get_document_by_transaction_id(foul_id):
+        """
+        Internal use only. Do not expose publicly as there is no user check.
+        """
         try:
             response = requests.get(
                 f"{settings.ATV_ENDPOINT}?transaction_id={foul_id}",


### PR DESCRIPTION
The endpoint was unused and had insufficient privilege controls.

refs: PSA-80