### PR TITLE
feat: use django-helsinki-health-endpoints for readiness and healthz

### DIFF
--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -33,7 +33,7 @@ env = Env(
     SENTRY_PROFILE_SESSION_SAMPLE_RATE=(float, None),
     SENTRY_RELEASE=(str, None),
     SENTRY_TRACES_SAMPLE_RATE=(float, None),
-    SENTRY_TRACES_IGNORE_PATHS=(list, ["/health", "/readiness"]),
+    SENTRY_TRACES_IGNORE_PATHS=(list, ["/healthz", "/readiness"]),
     ATV_API_KEY=(str, ""),
     ATV_ENDPOINT=(str, ""),
     TOKEN_AUTH_AUDIENCE=(list, []),
@@ -94,6 +94,9 @@ sentry_deny_list = DEFAULT_DENYLIST + [
     "httplib_request_kw",  # same as "body"
 ]
 
+# Django helsinki health endpoints
+SENTRY_RELEASE = env.str("SENTRY_RELEASE")
+
 SENTRY_TRACES_SAMPLE_RATE = env("SENTRY_TRACES_SAMPLE_RATE")
 SENTRY_TRACES_IGNORE_PATHS = env("SENTRY_TRACES_IGNORE_PATHS")
 
@@ -116,7 +119,7 @@ if env("SENTRY_DSN"):
     sentry_sdk.init(
         dsn=env("SENTRY_DSN"),
         environment=env("SENTRY_ENVIRONMENT"),
-        release=env("SENTRY_RELEASE"),
+        release=SENTRY_RELEASE,
         integrations=[DjangoIntegration()],
         traces_sampler=sentry_traces_sampler,
         profile_session_sample_rate=env("SENTRY_PROFILE_SESSION_SAMPLE_RATE"),
@@ -146,6 +149,7 @@ INSTALLED_APPS = [
     "mailer",
     "logger_extra",
     "resilient_logger",
+    "helsinki_health_endpoints",
 ]
 
 MIDDLEWARE = [

--- a/pysakoinnin_sahk_asiointi/tests/test_urls.py
+++ b/pysakoinnin_sahk_asiointi/tests/test_urls.py
@@ -3,11 +3,11 @@ import pytest
 
 @pytest.mark.django_db
 def test_health(client):
-    response = client.get("/health/")
+    response = client.get("/healthz")
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
 def test_readiness(client):
-    response = client.get("/readiness/")
+    response = client.get("/readiness")
     assert response.status_code == 200

--- a/pysakoinnin_sahk_asiointi/urls.py
+++ b/pysakoinnin_sahk_asiointi/urls.py
@@ -1,9 +1,7 @@
 """pysakoinnin_sahk_asiointi URL Configuration"""
 
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest
 from django.urls import include, path
-from django.views.decorators.cache import never_cache
-from django.views.decorators.http import require_safe
 from helusers.oidc import RequestJWTAuthentication
 from ninja import NinjaAPI
 from ninja.errors import HttpError
@@ -37,40 +35,8 @@ api.add_router("/", api_router)
 api.add_router("/gdpr", gdrp_api_router)
 
 
-#
-# Kubernetes liveness & readiness probes
-#
-@require_safe
-@never_cache
-def health(*_, **__):
-    return HttpResponse("OK", status=200)
-
-
-@require_safe
-@never_cache
-def readiness(*_, **__):
-    failed_check = False
-    try:
-        from django.db import connections
-
-        for name in connections:
-            cursor = connections[name].cursor()
-            cursor.execute("SELECT 1;")
-            row = cursor.fetchone()
-            if row is None:
-                failed_check = True
-    except Exception:
-        failed_check = True
-
-    if failed_check:
-        raise HttpError(500, message="Database issue")
-
-    return HttpResponse("OK", status=200)
-
-
 urlpatterns = [
-    path("health/", health),
-    path("readiness/", readiness),
     path("api/v1/", api.urls),
     path("helauth/", include("helusers.urls")),
+    path("", include("helsinki_health_endpoints.urls")),
 ]

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ django-cors-headers
 django-csp
 django-environ
 django-helusers
+django-helsinki-health-endpoints
 django-logger-extra
 django-mailer
 django-ninja

--- a/requirements.txt
+++ b/requirements.txt
@@ -297,6 +297,7 @@ django==5.2.12 \
     #   django-anymail
     #   django-cors-headers
     #   django-csp
+    #   django-helsinki-health-endpoints
     #   django-helsinki-suomifi-messages
     #   django-helusers
     #   django-logger-extra
@@ -319,6 +320,10 @@ django-csp==4.0 \
 django-environ==0.12.0 \
     --hash=sha256:227dc891453dd5bde769c3449cf4a74b6f2ee8f7ab2361c93a07068f4179041a \
     --hash=sha256:92fb346a158abda07ffe6eb23135ce92843af06ecf8753f43adf9d2366dcc0ca
+    # via -r requirements.in
+django-helsinki-health-endpoints==1.0.0 \
+    --hash=sha256:75670113e99bfd1fc23e317a3a22cff563140f495655c2a5f6ab219389dafd52 \
+    --hash=sha256:eebf1baa6917d7b0e11123aec191df773883102ec1653025a86d7037dba389e2
     # via -r requirements.in
 django-helsinki-suomifi-messages==1.0.0 \
     --hash=sha256:1e4d86f2e0da31db5d45535f8fd21265e09c3656e5f3e4a05ea155e88c15e811 \


### PR DESCRIPTION
Make use of django-helsinki-health-endpoints library to publish readiness and healthz endpoints.

Add SENTRY_RELEASE to django settings from env for the library.

Renames the health/ url to healthz and removes trailing slash from readiness url.

Refs: KEH-242