### PR TITLE
feat: increase gunicorn worker timeout from 30s to 60s

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -7,8 +7,8 @@ accesslog = "-"  # Log access to stdout
 errorlog = "-"  # Log errors to stderr
 limit_request_field_size = 65536  # Limit request header size
 capture_output = True  # Capture stdout/stderr in logs
-timeout = 30  # Timeout for requests in seconds
-graceful_timeout = 30  # Timeout for graceful shutdown
+timeout = 60  # Timeout for requests in seconds
+graceful_timeout = 60  # Timeout for graceful shutdown
 keepalive = 2  # Keep-alive time for connections in seconds
 enable_stdio_inheritance = True  # Inherit stdio from the parent process
 # Worker Restart Settings


### PR DESCRIPTION
Quite a lot of SystemExits in Sentry. The cause seems to be that [any request timeouts exceed the worker timeout](https://github.com/City-of-Helsinki/pysakoinnin-sahk-asiointi/blob/751f86ebdabf324c97b186039d002f21e028a203/pysakoinnin_sahk_asiointi/settings.py#L54).

This PR attempts to resolve issue by increasing gunicorn worker timeout and graceful timeout from 30 seconds to 60 seconds. It also matches the timeouts in projects using uwsgi, e.g. [Linked Events](https://github.com/City-of-Helsinki/linkedevents/blob/687ab1d47962b10c373fd9a37542e466e7fdea6e/.prod/uwsgi_configuration.ini#L48). Should hopefully reduce the amount of SystemExits.

Refs: PSA-164