### PR TITLE
feat!: remove sendDecisionViaEService from external API

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -16,6 +16,7 @@ from api.schemas import (
     FoulDataResponse,
     FoulRequest,
     Objection,
+    ObjectionRequest,
     TransferDataResponse,
 )
 from api.utils import virus_scan_attachment_file
@@ -123,7 +124,7 @@ def extend_due_date(request, foul_data: FoulRequest):
 @router.post(
     "/saveObjection", response={200: None, 204: None, 422: None}, tags=["PASI"]
 )
-def save_objection(request, objection: Objection):
+def save_objection(request, objection: ObjectionRequest):
     """
     Send a new objection to PASI
     """
@@ -170,7 +171,10 @@ def save_objection(request, objection: Objection):
     except Exception as error:
         raise ninja.errors.HttpError(500, message=str(error))
 
-    response = PASIHandler.save_objection(objection, objection_id)
+    internal_objection = Objection.model_construct(
+        **objection.model_dump(), sendDecisionViaEService=True
+    )
+    response = PASIHandler.save_objection(internal_objection, objection_id)
     return response.status_code
 
 

--- a/api/schemas.py
+++ b/api/schemas.py
@@ -80,7 +80,7 @@ class AddressField(Schema):
     countryName: str | None = None
 
 
-class Objection(Schema):
+class ObjectionRequest(Schema):
     foulNumber: int | None = None
     transferNumber: int | None = None
     folderID: str | None = None
@@ -96,8 +96,11 @@ class Objection(Schema):
     description: str
     attachments: list[AttachmentSchema] | None = None
     type: int
-    sendDecisionViaEService: bool
     metadata: dict | None = None
+
+
+class Objection(ObjectionRequest):
+    sendDecisionViaEService: bool
 
 
 class TransferDataResponse(Schema):

--- a/api/tests/__snapshots__/test_schema.ambr
+++ b/api/tests/__snapshots__/test_schema.ambr
@@ -737,7 +737,7 @@
           'title': 'NotFoundError',
           'type': 'object',
         }),
-        'Objection': dict({
+        'ObjectionRequest': dict({
           'properties': dict({
             'address': dict({
               '$ref': '#/components/schemas/AddressField',
@@ -830,10 +830,6 @@
               'title': 'Mobilephone',
               'type': 'string',
             }),
-            'sendDecisionViaEService': dict({
-              'title': 'Senddecisionviaeservice',
-              'type': 'boolean',
-            }),
             'ssn': dict({
               'title': 'Ssn',
               'type': 'string',
@@ -865,9 +861,8 @@
             'address',
             'description',
             'type',
-            'sendDecisionViaEService',
           ]),
-          'title': 'Objection',
+          'title': 'ObjectionRequest',
           'type': 'object',
         }),
         'PagedDeliveryReportSchema': dict({
@@ -1441,7 +1436,7 @@
             'content': dict({
               'application/json': dict({
                 'schema': dict({
-                  '$ref': '#/components/schemas/Objection',
+                  '$ref': '#/components/schemas/ObjectionRequest',
                 }),
               }),
             }),

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -101,6 +101,5 @@ def valid_objection_data():
         },
         "description": "I object to this fine",
         "type": 0,
-        "sendDecisionViaEService": True,
         "metadata": {},
     }

--- a/api/tests/test_api.py
+++ b/api/tests/test_api.py
@@ -62,7 +62,6 @@ class Objection(Schema):
     address: Address = Address()
     description: str = "string"
     type: int = 0
-    sendDecisionViaEService: bool = True
     metadata: dict = Metadata().dict()
     attachments: list = []
 

--- a/api/tests/test_objection_endpoint_field_validation.py
+++ b/api/tests/test_objection_endpoint_field_validation.py
@@ -49,7 +49,6 @@ class TestSaveObjectionEndpoint:
         },
         "description": "I object to this fine",
         "type": 0,
-        "sendDecisionViaEService": True,
         "metadata": {},
     }
 
@@ -72,6 +71,9 @@ class TestSaveObjectionEndpoint:
         # Verify the objection_id used was the foulNumber
         call_kwargs = add_doc_mock.call_args.kwargs
         assert call_kwargs.get("document_id") == 12345
+
+        pasi_objection = handler_mock.call_args.args[0]
+        assert pasi_objection.sendDecisionViaEService is True
 
     def test_save_objection_with_transfer_number(
         self, handler_mock, add_doc_mock, auth_mock, authenticated_client, user


### PR DESCRIPTION
Sending it always true to PASI.

Refs: PSA-173

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **API Changes**
  * Request shape for saving objections updated: one internal delivery flag is no longer accepted from clients and is now enforced by the server.
  * The endpoint strips attachment payloads before storage and continues to validate requester email and required identifiers.

* **Tests**
  * Test fixtures and endpoint validation tests updated to match the new request shape and server-side enforcement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->