### PR TITLE
fix: add root logger for Django

### DIFF
--- a/pysakoinnin_sahk_asiointi/settings.py
+++ b/pysakoinnin_sahk_asiointi/settings.py
@@ -338,6 +338,10 @@ LOGGING = {
             "()": "logger_extra.formatter.JSONFormatter",
         }
     },
+    "root": {
+        "handlers": ["console"],
+        "level": "INFO",
+    },
     "loggers": {
         "django": {
             "handlers": ["console"],


### PR DESCRIPTION
Root logger from gunicorn was causing errors for
application logging from Django.

Refs: PSA-177, PSA-178, PSA-179, PSA-180

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated logging setup to send general application logs to the console at a consistent `INFO` level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->