### PR TITLE
fix: abort suomifi command calls if feature is disabled

### DIFF
--- a/message_service/management/commands/retrieve_suomifi_read_status.py
+++ b/message_service/management/commands/retrieve_suomifi_read_status.py
@@ -1,6 +1,7 @@
 import logging
 
-from django.core.management.base import BaseCommand
+from django.conf import settings
+from django.core.management.base import BaseCommand, CommandError
 from suomifi_messages.schemas import EventType
 
 from message_service.enums import DeliveryStatus
@@ -28,6 +29,12 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        if not settings.SUOMIFI_MESSAGES_ENABLED:
+            raise CommandError(
+                "Suomi.fi messages disabled, aborting. To run this "
+                "command, set SUOMIFI_MESSAGES_ENABLED to true."
+            )
+
         persistence, _ = SuomifiPersistence.objects.get_or_create(pk=1)
 
         if options["all"]:

--- a/message_service/management/commands/send_messages.py
+++ b/message_service/management/commands/send_messages.py
@@ -2,7 +2,7 @@ from datetime import timedelta
 
 import sentry_sdk
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from message_service.enums import DeliveryStatus
@@ -14,6 +14,12 @@ class Command(BaseCommand):
     help = "Send all queued messages."
 
     def handle(self, *args, **options):
+        if not settings.SUOMIFI_MESSAGES_ENABLED:
+            raise CommandError(
+                "Suomi.fi messages disabled, aborting. To run this "
+                "command, set SUOMIFI_MESSAGES_ENABLED to true."
+            )
+
         messages = Message.objects.filter(queued=True)
         self.stdout.write(f"Queued message count: {messages.count()}")
 

--- a/message_service/tests/test_retrieve_suomifi_read_status_command.py
+++ b/message_service/tests/test_retrieve_suomifi_read_status_command.py
@@ -2,11 +2,16 @@ import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 from suomifi_messages.schemas import EventType
 
 from message_service.enums import DeliveryStatus
 from message_service.models import DeliveryReport, SuomifiPersistence
+
+
+@pytest.fixture(autouse=True)
+def setup_settings(settings):
+    settings.SUOMIFI_MESSAGES_ENABLED = True
 
 
 @pytest.fixture
@@ -21,6 +26,14 @@ def _make_event(event_type, suomifi_id, event_time):
     event.metadata.message_id = suomifi_id
     event.event_time = event_time
     return event
+
+
+@pytest.mark.django_db
+def test_raises_command_error_if_feature_not_enabled(settings):
+    settings.SUOMIFI_MESSAGES_ENABLED = False
+
+    with pytest.raises(CommandError, match="Suomi.fi messages disabled, aborting."):
+        call_command("retrieve_suomifi_read_status")
 
 
 @pytest.mark.django_db

--- a/message_service/tests/test_send_messages_command.py
+++ b/message_service/tests/test_send_messages_command.py
@@ -3,11 +3,24 @@ from io import StringIO
 from unittest.mock import patch
 
 import pytest
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 
 from message_service.enums import DeliveryStatus
 from message_service.models import Message
 from message_service.utils import PermanentSendError, TransientSendError
+
+
+@pytest.fixture(autouse=True)
+def setup_settings(settings):
+    settings.SUOMIFI_MESSAGES_ENABLED = True
+
+
+@pytest.mark.django_db
+def test_raises_command_error_if_feature_not_enabled(settings):
+    settings.SUOMIFI_MESSAGES_ENABLED = False
+
+    with pytest.raises(CommandError, match="Suomi.fi messages disabled, aborting."):
+        call_command("send_messages")
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
Refs: PSA-156

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Message-sending and read-status retrieval commands now stop with a clear error when Suomi.fi messaging is disabled, preventing unintended processing.

* **Tests**
  * Added coverage to verify both commands correctly reject execution when the messaging feature is turned off.
  * Existing command behavior remains covered when the feature is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->